### PR TITLE
[Speculation] Add Operations to enable Speculation

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -1265,22 +1265,22 @@ def SpeculatorOp : Handshake_Op<"speculator", [
 
     It needs to send control tokens to save units and commit units
     ($saveCtrl, $commitCtrl). For save-commit units, three control
-    signals are needed. $SCCtrl is connected directly, while 
-    $SCCtrlOptional replicates the branches that $dataOut
+    signals are needed. $SCSaveCtrl is connected directly, while 
+    $SCCommitCtrl replicates the branches that $dataOut
     follows and might not reach a save-commit. $SCBranchCtrl is needed
-    in the replicated branches to discard the optional signal.
+    in the replicated branches to discard the latter signal.
 
     Example:
     ```mlir
-    %dataOut, %saveCtrl, %commitCtrl, %SCCtrl, 
-      %SCCtrlOptional, %SCBranchCtrl = speculator %dataIn : i1
+    %dataOut, %saveCtrl, %commitCtrl, %SCSaveCtrl, 
+      %SCCommitCtrl, %SCBranchCtrl = speculator %dataIn : i1
     ```
   }];
 
   let arguments = (ins AnyType : $dataIn);
   let results = (outs AnyType : $dataOut,
                   I1 : $saveCtrl, I1 : $commitCtrl, 
-                  I<3> : $SCCtrl, I<3> : $SCCtrlOptional, 
+                  I<3> : $SCSaveCtrl, I<3> : $SCCommitCtrl, 
                   I1 : $SCBranchCtrl);
   let assemblyFormat = "$dataIn attr-dict `:` qualified(type($dataIn)) ";
 }

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -1377,22 +1377,3 @@ def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
   let arguments = (ins AnyType : $tagFromOperand, AnyType : $dataOperand);
   let results = (outs AnyType : $trueResult, AnyType : $falseResult);
 }
-
-def SpecSynchronizerOp : Handshake_Op<"spec_synchronizer"> {
-  let summary = "Make all tokens speculative if one input token is spec.";
-  let description = [{
-    Two basic blocks may represent multiple edges and have speculative and
-    non-speculative tokens interact.
-    Commit units can’t stop non-speculative tokens. As a result,
-    we need to add synchronizers before the commit units so that
-    if one of the tokens is speculative, all tokens become speculative.
-
-    Example:
-    ```mlir
-    <SSA results> = speculator <SSA operands>
-    ```
-  }];
-
-  let arguments = (ins Variadic<AnyType> : $inputs);
-  let results = (outs Variadic<AnyType> : $outputs);
-}

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -1249,3 +1249,124 @@ def EndOp : Handshake_Op<"end", [Terminator]> {
     mlir::ValueRange getMemoryControls();
   }];
 }
+
+//===----------------------------------------------------------------------===//
+// Speculation operations
+//===----------------------------------------------------------------------===//
+
+def SpeculatorOp : Handshake_Op<"speculator"> {
+  let summary = "Central control unit of the speculative circuit.";
+  let description = [{
+    The speculator produces speculative data tokens when real data has
+    not yet arrived. The speculator is also responsible for deciding 
+    the correctness of its speculation.
+
+    It needs to send control tokens to save units, commit units, 
+    and save-commit units.
+
+    Example:
+    ```mlir
+    <SSA results> = speculator <SSA operands>
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyType> : $inputs);
+  let results = (outs Variadic<AnyType> : $outputs);
+  let assemblyFormat = [{
+    `(` $inputs `)` attr-dict `:` functional-type($inputs, $outputs)
+  }];
+}
+
+def SpecSaveOp : Handshake_Op<"spec_save"> {
+  let summary = "Saves data tokens that interact in the speculative region.";
+  let description = [{
+    Save units are used to mark the beginning of the speculation region. 
+    Whenever a speculative token can interact with a non-speculative token, 
+    the non-speculative token needs to be saved. In case of correct speculation
+    or no speculation, the saved token can be dropped.
+
+    On the other hand, if the speculation was incorrect, the saved tokens 
+    need to be reinserted into the circuit to repeat the previously 
+    miscalculated computations.
+
+    Example:
+    ```mlir
+    <SSA results> = speculator <SSA operands>
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyType> : $inputs);
+  let results = (outs Variadic<AnyType> : $outputs);
+  let assemblyFormat = [{
+    `(` $inputs `)` attr-dict `:` functional-type($inputs, $outputs)
+  }];
+}
+
+def SpecCommitOp : Handshake_Op<"spec_commit"> {
+  let summary = "Stall speculative data tokens until they are resolved.";
+  let description = [{
+    Commit units are used to mark the end of the speculation region. 
+    Commit units are used to stall speculative tokens until they receive 
+    the decision from the speculator. In case the speculation is correct, 
+    the speculative tokens are converted into non-speculative tokens and 
+    passed on to the rest of the circuit. 
+    Otherwise, the speculative tokens are discarded. 
+
+    Any non-speculative token can pass through the commit units 
+    without any stall.
+
+    Example:
+    ```mlir
+    <SSA results> = speculator <SSA operands>
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyType> : $inputs);
+  let results = (outs Variadic<AnyType> : $outputs);
+  let assemblyFormat = [{
+    `(` $inputs `)` attr-dict `:` functional-type($inputs, $outputs)
+  }];
+}
+
+def SpecSaveCommitOp : Handshake_Op<"spec_save_commit"> {
+  let summary = "Lets all tokens pass and saves a copy of them.";
+  let description = [{
+    Save-Commits are used when speculation occurs in a loop.
+    To increase loop parallelism, the save-commit unit will let both
+    speculative and non-speculative tokens pass as well as save
+    a copy of them.
+
+    Example:
+    ```mlir
+    <SSA results> = speculator <SSA operands>
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyType> : $inputs);
+  let results = (outs Variadic<AnyType> : $outputs);
+  let assemblyFormat = [{
+    `(` $inputs `)` attr-dict `:` functional-type($inputs, $outputs)
+  }];
+}
+
+def SpecSynchronizerOp : Handshake_Op<"spec_synchronizer"> {
+  let summary = "Make all tokens speculative if one input token is spec.";
+  let description = [{
+    Two basic blocks may represent multiple edges and have speculative and
+    non-speculative tokens interact.
+    Commit units can’t stop non-speculative tokens. As a result,
+    we need to add synchronizers before the commit units so that
+    if one of the tokens is speculative, all tokens become speculative.
+
+    Example:
+    ```mlir
+    <SSA results> = speculator <SSA operands>
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyType> : $inputs);
+  let results = (outs Variadic<AnyType> : $outputs);
+  let assemblyFormat = [{
+    `(` $inputs `)` attr-dict `:` functional-type($inputs, $outputs)
+  }];
+}

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -1263,23 +1263,26 @@ def SpeculatorOp : Handshake_Op<"speculator", [
     not yet arrived. The speculator is also responsible for deciding 
     the correctness of its speculation.
 
-    It needs to send control tokens to save units, commit units, 
-    and save-commit units.
+    It needs to send control tokens to save units and commit units
+    ($saveCtrl, $commitCtrl). For save-commit units, three control
+    signals are needed. $SCCtrl is connected directly, while 
+    $SCCtrlOptional replicates the branches that $dataOut
+    follows and might not reach a save-commit. $SCBranchCtrl is needed
+    in the replicated branches to discard the optional signal.
 
     Example:
     ```mlir
-    %dataOut, %saveCtrl, %commitCtrl, %SCControl1, %SCControl2, 
-      %SCBranchControl = "handshake.speculator"(%dataOut) 
-      {name = #handshake.name<"speculator0">} : 
-      (i1) -> (i1, i1, i1, i3, i3, i1)
+    %dataOut, %saveCtrl, %commitCtrl, %SCCtrl, 
+      %SCCtrlOptional, %SCBranchCtrl = speculator %dataIn : i1
     ```
   }];
 
   let arguments = (ins AnyType : $dataIn);
   let results = (outs AnyType : $dataOut,
                   I1 : $saveCtrl, I1 : $commitCtrl, 
-                  I<3> : $SCControl1, I<3> : $SCControl2, 
-                  I1 : $SCBranchControl);
+                  I<3> : $SCCtrl, I<3> : $SCCtrlOptional, 
+                  I1 : $SCBranchCtrl);
+  let assemblyFormat = "$dataIn attr-dict `:` qualified(type($dataIn)) ";
 }
 
 def SpecSaveOp : Handshake_Op<"spec_save", [
@@ -1298,13 +1301,13 @@ def SpecSaveOp : Handshake_Op<"spec_save", [
 
     Example:
     ```mlir
-    %23 = "handshake.spec_save"(%22, %saveCtrl) 
-      {name = #handshake.name<"spec_save1">} : (i1, i1) -> i1
+    %dataOut = spec_save[%ctrl] %dataIn : i11
     ```
   }];
 
   let arguments = (ins AnyType : $dataIn, I1 : $ctrl);
   let results = (outs AnyType : $dataOut);
+  let assemblyFormat = " `[` $ctrl `]` $dataIn attr-dict `:` qualified(type($dataIn)) ";
 }
 
 def SpecCommitOp : Handshake_Op<"spec_commit", [
@@ -1324,13 +1327,13 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
 
     Example:
     ```mlir
-     %40 = "handshake.spec_commit"(%result, %commitCtrl) 
-      {name = #handshake.name<"spec_commit0">} : (i1, i1) -> i1
+    %dataOut = spec_commit[%ctrl] %dataIn : i11
     ```
   }];
 
   let arguments = (ins AnyType : $dataIn, I1 : $ctrl);
   let results = (outs AnyType : $dataOut);
+  let assemblyFormat = " `[` $ctrl `]` $dataIn attr-dict `:` qualified(type($dataIn)) ";
 }
 
 def SpecSaveCommitOp : Handshake_Op<"spec_save_commit", [
@@ -1345,13 +1348,13 @@ def SpecSaveCommitOp : Handshake_Op<"spec_save_commit", [
  
     Example:
     ```mlir
-    %44 = "handshake.spec_save_commit"(%falseResult_7, %SCBranchControl) 
-      {name = #handshake.name<"spec_save_commit1">} : (i1, i3) -> i1
+    %dataOut = spec_save_commit[%ctrl] %dataIn : i11
     ```
   }];
 
   let arguments = (ins AnyType : $dataIn, I<3> : $ctrl);
   let results = (outs AnyType : $dataOut);
+  let assemblyFormat = " `[` $ctrl `]` $dataIn attr-dict `:` qualified(type($dataIn)) ";
 }
 
 def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
@@ -1366,14 +1369,18 @@ def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
      branch that decides the condition based on if a token Value is
      speculative or not. 
 
+     The $tagFromOperand field is the condition. Depending on wether the data
+     is speculative or not, $dataOperand will be send to $trueResult or 
+     $falseResult. The speculative tag is a fictious attribute.
+
      Example:
      ```mlir
-    %trueResult_12, %falseResult_13 = "handshake.speculating_branch"(
-      %trueResult_16, %42#0) {name = #handshake.name<"speculating_branch0">} : 
-      (i11, i1) -> (i1, i1)
+     %trueResult, %falseResult = 
+       speculating_branch[%tagFromOperand] %dataOperand : i32, i1
      ```
   }];
 
   let arguments = (ins AnyType : $tagFromOperand, AnyType : $dataOperand);
   let results = (outs AnyType : $trueResult, AnyType : $falseResult);
+  let assemblyFormat = " `[` $tagFromOperand `]` $dataOperand attr-dict `:` qualified(type($tagFromOperand)) `,` qualified(type($dataOperand)) ";
 }

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -1254,10 +1254,12 @@ def EndOp : Handshake_Op<"end", [Terminator]> {
 // Speculation operations
 //===----------------------------------------------------------------------===//
 
-def SpeculatorOp : Handshake_Op<"speculator"> {
+def SpeculatorOp : Handshake_Op<"speculator", [ 
+  TypesMatchWith<"data operand type matches data result type",
+                 "dataIn", "dataOut", "$_self">]> {
   let summary = "Central control unit of the speculative circuit.";
   let description = [{
-    The speculator produces speculative data tokens when real data has
+    The speculator produces speculative tokens when real data has
     not yet arrived. The speculator is also responsible for deciding 
     the correctness of its speculation.
 
@@ -1266,18 +1268,23 @@ def SpeculatorOp : Handshake_Op<"speculator"> {
 
     Example:
     ```mlir
-    <SSA results> = speculator <SSA operands>
+    %dataOut, %saveCtrl, %commitCtrl, %SCControl1, %SCControl2, 
+      %SCBranchControl = "handshake.speculator"(%dataOut) 
+      {name = #handshake.name<"speculator0">} : 
+      (i1) -> (i1, i1, i1, i3, i3, i1)
     ```
   }];
 
-  let arguments = (ins Variadic<AnyType> : $inputs);
-  let results = (outs Variadic<AnyType> : $outputs);
-  let assemblyFormat = [{
-    `(` $inputs `)` attr-dict `:` functional-type($inputs, $outputs)
-  }];
+  let arguments = (ins AnyType : $dataIn);
+  let results = (outs AnyType : $dataOut,
+                  I1 : $saveCtrl, I1 : $commitCtrl, 
+                  I<3> : $SCControl1, I<3> : $SCControl2, 
+                  I1 : $SCBranchControl);
 }
 
-def SpecSaveOp : Handshake_Op<"spec_save"> {
+def SpecSaveOp : Handshake_Op<"spec_save", [
+  TypesMatchWith<"data operand type matches data result type",
+                 "dataIn", "dataOut", "$_self">] > {
   let summary = "Saves data tokens that interact in the speculative region.";
   let description = [{
     Save units are used to mark the beginning of the speculation region. 
@@ -1291,18 +1298,18 @@ def SpecSaveOp : Handshake_Op<"spec_save"> {
 
     Example:
     ```mlir
-    <SSA results> = speculator <SSA operands>
+    %23 = "handshake.spec_save"(%22, %saveCtrl) 
+      {name = #handshake.name<"spec_save1">} : (i1, i1) -> i1
     ```
   }];
 
-  let arguments = (ins Variadic<AnyType> : $inputs);
-  let results = (outs Variadic<AnyType> : $outputs);
-  let assemblyFormat = [{
-    `(` $inputs `)` attr-dict `:` functional-type($inputs, $outputs)
-  }];
+  let arguments = (ins AnyType : $dataIn, I1 : $ctrl);
+  let results = (outs AnyType : $dataOut);
 }
 
-def SpecCommitOp : Handshake_Op<"spec_commit"> {
+def SpecCommitOp : Handshake_Op<"spec_commit", [
+  TypesMatchWith<"data operand type matches data result type",
+                    "dataIn", "dataOut", "$_self">] > {
   let summary = "Stall speculative data tokens until they are resolved.";
   let description = [{
     Commit units are used to mark the end of the speculation region. 
@@ -1317,36 +1324,58 @@ def SpecCommitOp : Handshake_Op<"spec_commit"> {
 
     Example:
     ```mlir
-    <SSA results> = speculator <SSA operands>
+     %40 = "handshake.spec_commit"(%result, %commitCtrl) 
+      {name = #handshake.name<"spec_commit0">} : (i1, i1) -> i1
     ```
   }];
 
-  let arguments = (ins Variadic<AnyType> : $inputs);
-  let results = (outs Variadic<AnyType> : $outputs);
-  let assemblyFormat = [{
-    `(` $inputs `)` attr-dict `:` functional-type($inputs, $outputs)
-  }];
+  let arguments = (ins AnyType : $dataIn, I1 : $ctrl);
+  let results = (outs AnyType : $dataOut);
 }
 
-def SpecSaveCommitOp : Handshake_Op<"spec_save_commit"> {
+def SpecSaveCommitOp : Handshake_Op<"spec_save_commit", [
+  TypesMatchWith<"data operand type matches data result type",
+                    "dataIn", "dataOut", "$_self">]> {
   let summary = "Lets all tokens pass and saves a copy of them.";
   let description = [{
     Save-Commits are used when speculation occurs in a loop.
     To increase loop parallelism, the save-commit unit will let both
     speculative and non-speculative tokens pass as well as save
     a copy of them.
-
+ 
     Example:
     ```mlir
-    <SSA results> = speculator <SSA operands>
+    %44 = "handshake.spec_save_commit"(%falseResult_7, %SCBranchControl) 
+      {name = #handshake.name<"spec_save_commit1">} : (i1, i3) -> i1
     ```
   }];
 
-  let arguments = (ins Variadic<AnyType> : $inputs);
-  let results = (outs Variadic<AnyType> : $outputs);
-  let assemblyFormat = [{
-    `(` $inputs `)` attr-dict `:` functional-type($inputs, $outputs)
+  let arguments = (ins AnyType : $dataIn, I<3> : $ctrl);
+  let results = (outs AnyType : $dataOut);
+}
+
+def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
+  TypesMatchWith<"data operand type matches true branch result type",
+                    "dataOperand", "trueResult", "$_self">,
+  TypesMatchWith<"data operand type matches false branch result type",
+                    "dataOperand", "falseResult", "$_self">
+]> {
+  let summary = "speculating branch operation";
+  let description = [{
+     The speculating branch operation represents a conditional
+     branch that decides the condition based on if a token Value is
+     speculative or not. 
+
+     Example:
+     ```mlir
+    %trueResult_12, %falseResult_13 = "handshake.speculating_branch"(
+      %trueResult_16, %42#0) {name = #handshake.name<"speculating_branch0">} : 
+      (i11, i1) -> (i1, i1)
+     ```
   }];
+
+  let arguments = (ins AnyType : $tagFromOperand, AnyType : $dataOperand);
+  let results = (outs AnyType : $trueResult, AnyType : $falseResult);
 }
 
 def SpecSynchronizerOp : Handshake_Op<"spec_synchronizer"> {
@@ -1366,7 +1395,4 @@ def SpecSynchronizerOp : Handshake_Op<"spec_synchronizer"> {
 
   let arguments = (ins Variadic<AnyType> : $inputs);
   let results = (outs Variadic<AnyType> : $outputs);
-  let assemblyFormat = [{
-    `(` $inputs `)` attr-dict `:` functional-type($inputs, $outputs)
-  }];
 }


### PR DESCRIPTION
Speculative execution involves speculating on the output of a long latency operation or chain of operations, allowing operations that depend on it to begin execution early, without impacting correctness.

This pull-request adds four Operations:
- SpeculatorOp. Drives Speculation process and connects to the other units.
- SpecSaveOp. Marks beginning of speculation path.
- SpecCommitOp. Marks end of speculation path.
- SpecSaveCommitOp. Joint Save and Commit that occurs when backedges (self-loops) are present.

The definitions do not include a custom assembly format. If needed, I can add it and would require some indications on how to do so.

This PR is needed for a parent PR in dynamatic.